### PR TITLE
add build commands for individual OS binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "prestart": "tsc",
     "start": "node ./dist/float.js",
     "startHeadless": "tsc && node ./dist/float.js --headless",
-    "build": "tsc && pkg ./dist/float.js --out-path=./build -t latest-linux,latest-mac,latest-win "
+    "build": "tsc && pkg ./dist/float.js --out-path=./build -t latest-linux,latest-mac,latest-win",
+    "buildLinux": "tsc && pkg ./dist/float.js --out-path=./build -t latest-linux",
+    "buildMac": "tsc && pkg ./dist/float.js --out-path=./build -t latest-mac",
+    "buildWin": "tsc && pkg ./dist/float.js --out-path=./build -t latest-win"
   },
   "dependencies": {
     "@ctrl/plex": "^1.5.3",


### PR DESCRIPTION
Some versions of node/npm can error out building binaries for certain operating systems so it's convenient to build only a specific binary on demand