### PR TITLE
sort the qualities returned from floatplane to guarantee ascending or…

### DIFF
--- a/src/lib/Video.ts
+++ b/src/lib/Video.ts
@@ -138,11 +138,7 @@ export default class Video {
 		if (settings.floatplane.downloadEdge !== '') downloadEdge.hostname = settings.floatplane.downloadEdge;
 
 		// Convert the qualities into an array of resolutions and sorts them smallest to largest
-		const availableQualities = cdnInfo.resource.data.qualityLevels.map((quality) => quality.name).sort((left, right): number => {
-			if(Number(left) < Number(right)) return -1;
-			if(Number(left) > Number(right)) return 1;
-			return 0;
-		});
+		const availableQualities = cdnInfo.resource.data.qualityLevels.map((quality) => quality.name).sort((a, b) => ~b - ~a);
 
 		// Set the quality to use based on whats given in the settings.json or the highest available
 		const downloadQuality = availableQualities.includes(quality) ? quality : availableQualities[availableQualities.length - 1];

--- a/src/lib/Video.ts
+++ b/src/lib/Video.ts
@@ -137,11 +137,15 @@ export default class Video {
 		const downloadEdge = cdnInfo.edges[Math.floor(Math.random() * cdnInfo.edges.length)];
 		if (settings.floatplane.downloadEdge !== '') downloadEdge.hostname = settings.floatplane.downloadEdge;
 
-		// Convert the qualities into an array of resolutions
-		const avalibleQualities = cdnInfo.resource.data.qualityLevels.map((quality) => quality.name);
+		// Convert the qualities into an array of resolutions and sorts them smallest to largest
+		const availableQualities = cdnInfo.resource.data.qualityLevels.map((quality) => quality.name).sort((left, right): number => {
+			if(Number(left) < Number(right)) return -1;
+			if(Number(left) > Number(right)) return 1;
+			return 0;
+		});
 
-		// Set the quality to use based on whats given in the settings.json or the highest avalible
-		const downloadQuality = avalibleQualities.includes(quality) ? quality : avalibleQualities[avalibleQualities.length - 1];
+		// Set the quality to use based on whats given in the settings.json or the highest available
+		const downloadQuality = availableQualities.includes(quality) ? quality : availableQualities[availableQualities.length - 1];
 
 		const downloadRequest = fApi.got.stream(
 			`https://${downloadEdge.hostname}${cdnInfo.resource.uri.replace('{qualityLevels}', downloadQuality).replace('{token}', cdnInfo.resource.data.token)}`,


### PR DESCRIPTION
…der of resolution

I found that Floatplane can provide the available qualities in random order leading to a 360p video being downloaded instead of the highest available quality when the requested resolution is unavailable