### PR TITLE
Fix typo in wiki

### DIFF
--- a/wiki/docker.md
+++ b/wiki/docker.md
@@ -27,7 +27,7 @@ There is a interactive series of console prompts to help you setup the downloade
     	-v [path]:/fp/db \
     	-v [path]:/fp/videos \
     	-e headless="true" \
-        inrixia/floatplane-downloader
+        inrix/floatplane-downloader
 
 <br>
 


### PR DESCRIPTION
docker repo is wrong in one instance of the wiki