### PR TITLE
Add identifiers for if a video was released before or after a specified time

### DIFF
--- a/src/lib/Subscription.ts
+++ b/src/lib/Subscription.ts
@@ -75,8 +75,8 @@ export default class Subscription {
 						return channel.addVideo(video);
 					}
 					if (
-						(identifier.type === "releasedBefore" && video.releaseDate < +identifier.check) ||
-						(identifier.type === "releasedAfter" && video.releaseDate > +identifier.check)
+						(identifier.type === "releasedBefore" && video.releaseDate < identifier.check) ||
+						(identifier.type === "releasedAfter" && video.releaseDate > identifier.check)
 					) {
 						if (channel.skip === true) return null;
 						return channel.addVideo(video);

--- a/src/lib/Subscription.ts
+++ b/src/lib/Subscription.ts
@@ -74,6 +74,13 @@ export default class Subscription {
 						if (channel.skip === true) return null;
 						return channel.addVideo(video);
 					}
+					if (
+						(identifier.type === "releasedBefore" && video.releaseDate < +identifier.check) ||
+						(identifier.type === "releasedAfter" && video.releaseDate > +identifier.check)
+					) {
+						if (channel.skip === true) return null;
+						return channel.addVideo(video);
+					}
 
 					// Description is named text on videos, kept description for ease of use for users but have to change it here...
 					const identifierType = identifier.type === "description" ? "text" : identifier.type;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,7 +5,7 @@ import type { BlogPost } from "floatplane/creator";
 
 type ChannelIdentifier = {
 	check: string;
-	type: keyof BlogPost | "description" | "runtimeLessThan" | "runtimeGreaterThan" | "channelId";
+	type: keyof BlogPost | "description" | "runtimeLessThan" | "runtimeGreaterThan" | "channelId" | "releasedBefore" | "releasedAfter";
 };
 export type ChannelOptions = {
 	title: string;

--- a/wiki/settings.md
+++ b/wiki/settings.md
@@ -242,7 +242,7 @@ An Identifier contains two entries `check` and `type`.<br>
 `check` is the string to look for.<br>
 `type` is where in the video returned from the floatplane api to search for the check string.
 This can be `description`, `title` etc any property that exists on the video. See [FloatplaneApiDocs/getBlogPost](https://jman012.github.io/FloatplaneAPIDocs/Redoc/redoc-static.html#operation/getBlogPost) for more info...
-You can also use `runtimeLessThan` and `runtimeGreaterThan` to only match videos whos runtime is greated or lower than the specified value in seconds. This can be used with a generic skip channel to skip videos with a runtime greater or less than the desired amount.<br>
+The identifiers `releasedAfter` and `releasedBefore` can also be used to match videos that were released before or after a specified date. You can also use `runtimeLessThan` and `runtimeGreaterThan` to only match videos whos runtime is greated or lower than the specified value in seconds. This can be used with a generic skip channel to skip videos with a runtime greater or less than the desired amount.<br>
 <br>
 
 For example:
@@ -261,7 +261,6 @@ For example:
 }
 ```
 <br>
-The identifiers `releasedAfter` and `releasedBefore` can also be used to match videos that were released before or after a specified date.
 
 
 This is a channel named "Floatplane Exclusive".<br>

--- a/wiki/settings.md
+++ b/wiki/settings.md
@@ -260,6 +260,9 @@ For example:
     "daysToKeepVideos": 5
 }
 ```
+<br>
+The identifiers `releasedAfter` and `releasedBefore` can also be used to match videos that were released before or after a specified date.
+
 
 This is a channel named "Floatplane Exclusive".<br>
 Videos that have "FP Exclusive: " in their title will be sorted into this channel.<br>

--- a/wiki/settings.md
+++ b/wiki/settings.md
@@ -241,7 +241,7 @@ A **channel** is made up of a `title`, `skip`, an array of `identifiers` and `co
 An Identifier contains two entries `check` and `type`.<br>
 `check` is the string to look for.<br>
 `type` is where in the video returned from the floatplane api to search for the check string.
-This can be `description`, `title` etc any property that exists on the video. See [FloatplaneApiDocs/getBlogPost](https://jman012.github.io/FloatplaneAPIDocs/Redoc/redoc-static.html#operation/getBlogPost) for more info...
+This can be `description`, `title` etc any property that exists on the video. See [FloatplaneApiDocs/getBlogPost](https://jman012.github.io/FloatplaneAPIDocs/Redoc/redoc-static.html#operation/getBlogPost) for more info...<br>
 The identifiers `releasedAfter` and `releasedBefore` can also be used to match videos that were released before or after a specified date. You can also use `runtimeLessThan` and `runtimeGreaterThan` to only match videos whos runtime is greated or lower than the specified value in seconds. This can be used with a generic skip channel to skip videos with a runtime greater or less than the desired amount.<br>
 <br>
 


### PR DESCRIPTION
This adds the identifiers 'releasedBefore' and 'releasedAfter'. This allows downloading videos before or after the specified date/time.
