### PR TITLE
Quick hack to strip descriptions all together on per channel basis

### DIFF
--- a/src/lib/Subscription.ts
+++ b/src/lib/Subscription.ts
@@ -151,6 +151,10 @@ export default class Subscription {
 							post.title = post.title.replace(regIdCheck, "");
 						}
 
+						if (channel.ignoreDescription === true) {
+							post.text = "";
+						}
+
 						post.title = post.title.replaceAll("  ", " ");
 						if (post.title.startsWith(": ")) post.title = post.title.replace(": ", "");
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,6 +12,7 @@ export type ChannelOptions = {
 	skip: boolean;
 	identifiers?: ChannelIdentifier[];
 	daysToKeepVideos?: number;
+	ignoreDescription?: boolean;
 };
 
 export type Channels = ChannelOptions[];


### PR DESCRIPTION
This will add a new field on channels called `ignoreDescription` which will strip out descriptions for the channel. 


My use case is that I use Jellyfin on a small tablet and the large blobs of text makes my viewing experience not so ideal.