### PR TITLE
Switch to current-alpine to slim down Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest AS build
+FROM node:current-alpine AS build
 
 # working directory for the build
 WORKDIR ${HOME}
@@ -16,7 +16,7 @@ COPY ./src ${HOME}/src
 RUN npx tsc
 
 # Copy built artifacts and dependencies into a minimal release image
-FROM node:slim AS release
+FROM node:current-alpine AS release
 
 LABEL Description="Project for automatically organizing and downloading Floatplane videos for plex."
 


### PR DESCRIPTION
This PR will change the base Docker images to use the latest Node version on top of the slimmed down Alpine images. 