### PR TITLE
Add a extras field to ignore video descriptions

### DIFF
--- a/src/lib/Subscription.ts
+++ b/src/lib/Subscription.ts
@@ -130,6 +130,10 @@ export default class Subscription {
 						videoTitle = videoTitle.replace(regIdCheck, "");
 					}
 
+					if (settings.extras.removeVideoDescription === true) {
+						post.text = "";
+					}
+
 					videoTitle = videoTitle.replaceAll("  ", " ");
 					if (videoTitle.startsWith(": ")) videoTitle = videoTitle.replace(": ", "");
 

--- a/src/lib/defaults.ts
+++ b/src/lib/defaults.ts
@@ -57,6 +57,7 @@ export const defaultSettings: Settings = {
 		downloadArtwork: true,
 		saveNfo: true,
 		considerAllNonPartialDownloaded: false,
+		removeVideoDescription: false,
 	},
 	artworkSuffix: "",
 	postProcessingCommand: "",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -42,6 +42,7 @@ export type Extras = {
 	downloadArtwork: boolean;
 	saveNfo: boolean;
 	considerAllNonPartialDownloaded: boolean;
+	removeVideoDescription: boolean;
 };
 
 export type Resolution = ValueOfA<Resolutions>;

--- a/wiki/settings.md
+++ b/wiki/settings.md
@@ -134,7 +134,16 @@ vs
 
 <br>
 
-**extras.downloadArtwork**:  
+**extras.removeVideoDescription**:
+Removes the Video Description from the video metadata when the Video is downloaded.
+
+```json
+"extras": {
+    "removeVideoDescription": false
+}
+```
+
+**extras.downloadArtwork**:
 Saves video thubnails alongside each video. These are required for nice thumbnails in Plex.
 
 ```json


### PR DESCRIPTION
This PR will add a new extras field called `removeVideoDescription` to remove the video descriptions in the metadata and NFO.

By default, this field will be `false` and will not remove the video description. This will ensure that existing functionality is preserved and won't effect existing users of Floatplane Downloader.