### PR TITLE
Add Channel selection during quick Start

### DIFF
--- a/src/lib/prompts/settings.ts
+++ b/src/lib/prompts/settings.ts
@@ -1,5 +1,5 @@
 import prompts from "prompts";
-import type { Extras, Resolution } from "../types.js";
+import { Channels, PROMPT_CONFIRM, Settings, type Extras, type Resolution } from "../types.js";
 import { Video } from "../Video.js";
 
 /**
@@ -79,3 +79,26 @@ export const daysToKeepVideos = async (initial: number): Promise<number> =>
 			min: 1,
 		})
 	).daysToKeepVideos || initial;
+
+export const multiSelectChannelPrompt = async (initial: Channels): Promise<string[]> => {
+	return (
+		await prompts({
+			type: "multiselect",
+			name: "downloadChannels",
+			message: "Enable/Disable channels:",
+			choices: initial.map((initial) => ({ title: initial.title, value: initial.title, selected: !initial.skip })),
+			hint: "- Space to select. Return to submit",
+		})
+	).downloadChannels;
+};
+
+export const selectSubscriptionPrompt = async (initial: Settings["subscriptions"]): Promise<string> => {
+	return (
+		await prompts({
+			type: "select",
+			name: "subscription",
+			message: "Select a subscription",
+			choices: [...Object.keys(initial).map((option) => ({ title: initial[option].plan, value: option })), { title: "Confirm", value: PROMPT_CONFIRM }],
+		})
+	).subscription;
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -69,3 +69,5 @@ export type Settings = {
 		contributeMetrics: boolean;
 	};
 };
+
+export const PROMPT_CONFIRM = "confirm";


### PR DESCRIPTION
This PR add channel selection during Quick Start. It allow user to skip selected channel easily, instead of modifying the `settings.json` file


https://github.com/user-attachments/assets/bbb11642-4c57-4ce3-af2a-f4d56cbeb908

I only have an LTT subscriptions so I cannot test using multiple subscription. I have updated the prompt to take settings as argument, and moved the prompt logic to another function.

For some reason, I don't have all the channels linked to the subscription. If I deselect all, everything is skipped except those 4. You may have more info than me
```json
{
	"title": "TalkLinked",
	"skip": false,
	"isChannel": "(post) => post.title?.toLowerCase().includes('talklinked')"
},
{
	"title": "TechLinked Shorts",
	"skip": false,
	"isChannel": "(post) => post.title?.toLowerCase().includes('tl short: ')"
},
{
	"title": "The WAN Show",
	"skip": false,
	"isChannel": "(post) => post.title?.toLowerCase().includes('wan show')"
},
{
	"title": "LMG Livestream VODs",
	"skip": false,
	"isChannel": "(post) => post.title?.toLowerCase().includes('livestream vod – ')"
}
```