### PR TITLE
Add trackVideoIDs

### DIFF
--- a/src/lib/Attachment.ts
+++ b/src/lib/Attachment.ts
@@ -11,6 +11,7 @@ import { nll } from "./logging/ProgressLogger";
 type AttachmentInfo = {
 	partialBytes?: number;
 	muxedBytes?: number;
+	muxed?: boolean;
 	filePath: string;
 	releaseDate: number;
 	videoTitle: string;

--- a/src/lib/Video.ts
+++ b/src/lib/Video.ts
@@ -139,6 +139,8 @@ export class Video extends Attachment {
 							}
 						}
 					}
+					const attrStore = await this.attachmentInfo();
+					attrStore.muxed = true;
 					telegramMsg(`Downloaded ${this.videoTitle} from ${this.channelTitle}`);
 					discordEmbed("New video downloaded", this);
 					this.logger.done(chalk`{cyan Downloaded!}`);
@@ -217,9 +219,12 @@ export class Video extends Attachment {
 	public async getState() {
 		const attrStore = await this.attachmentInfo();
 
+		if (settings.floatplane.trackVideoIDs && attrStore.muxed) return VideoState.Muxed;
+
 		const muxedBytes = await Video.pathBytes(this.muxedPath);
 		// If considerAllNonPartialDownloaded is true, return true if the file exists. Otherwise check if the file is the correct size
 		if (settings.extras.considerAllNonPartialDownloaded && muxedBytes !== -1) attrStore.muxedBytes = muxedBytes;
+		if (settings.floatplane.trackVideoIDs && attrStore.muxedBytes === muxedBytes) attrStore.muxed = true;
 		if (attrStore.muxedBytes === muxedBytes) return VideoState.Muxed;
 
 		const partialBytes = await Video.pathBytes(this.partialPath);

--- a/src/lib/defaults.ts
+++ b/src/lib/defaults.ts
@@ -46,6 +46,7 @@ export const defaultSettings: Settings = {
 		videosToSearch: 5,
 		videoResolution: "1080",
 		waitForNewVideos: true,
+		trackVideoIDs: false,
 		seekAndDestroy: [],
 	},
 	maxDownloadSpeed: -1,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -68,6 +68,7 @@ export type Settings = {
 		videoResolution: Resolution;
 		videosToSearch: number;
 		waitForNewVideos: boolean;
+		trackVideoIDs: boolean;
 		seekAndDestroy: string[];
 	};
 	maxDownloadSpeed: number;

--- a/wiki/settings.md
+++ b/wiki/settings.md
@@ -50,6 +50,19 @@ Controls if the downloader should wait for new videos to download after finishin
 
 <br>
 
+
+**floatplane.trackVideoIDs**:  
+Controls if the downloader should redownload a video if the video file can't be found. Setting this to `true` will not redownload even if the video file has been moved, renamed or deleted.  
+If you move or rename a video file with this enabled it will not automatically be deleted after `daysToKeepVideos`.
+
+```json
+"floatplane": {
+    "trackVideoIDs": true
+}
+```
+
+<br>
+
 **floatplane.seekAndDestroy**:  
 You can put video id's here and the downloader will find, sort and download them normally.
 


### PR DESCRIPTION
Fixes #241 by adding a setting called `trackVideoIDs` that can track if a video has already been downloaded and not download it again, even if the file has been moved, renamed or deleted.

This works by adding a new value to `attachments.json` called `muxed` that is set to true once the video has been fully downloaded and muxed. If `muxed` is true the program will just treat that video as muxed, even if it can't find it.

However, if a video file is moved or renamed this won't be able to delete it after `daysToKeepVideos`.