### PR TITLE
Download Captions

### DIFF
--- a/src/float.ts
+++ b/src/float.ts
@@ -45,7 +45,7 @@ const downloadNewVideos = async () => {
 		}
 		await subscription.deleteOldVideos();
 		for await (const video of subscription.fetchNewVideos()) inProgress.push(video.download());
-		await findTextTracks(subscription);
+		if (settings.extras.downloadCaptions) await findTextTracks(subscription);
 	}
 
 	console.log(chalk`Queued {green ${inProgress.length}} videos...`);

--- a/src/float.ts
+++ b/src/float.ts
@@ -115,9 +115,12 @@ const findTextTracks = async (subscription: Subscription) => {
 	console.log(chalk`Checking for missing text tracks in {yellow ${subscription.plan}}...`);
 	let tracksAdded = 0;
 
-	for (const videoData of Attachment.find((attachment: any) => {
+	// Find videos for this subscription and sort by release date (newest first)
+	const videoDataList = Attachment.find((attachment: any) => {
 		return subscription.channels.some((channel: ChannelOptions) => channel.title === attachment.channelTitle);
-	})) {
+	}).sort((a, b) => b.releaseDate - a.releaseDate).slice(0, settings.floatplane.videosToSearch);
+
+	for (const videoData of videoDataList) {
 		const video = Video.Videos[videoData.attachmentId];
 		
 		if (!video || (video.textTracks && video.textTracks.length > 0)) continue;

--- a/src/lib/Subscription.ts
+++ b/src/lib/Subscription.ts
@@ -59,11 +59,6 @@ export default class Subscription {
 	private static isChannelCache: Record<string, isChannel> = {};
 	private static isChannelHelper = `const isChannel = (post, channelId) => (typeof post.channel !== 'string' ? post.channel.id : post.channel) === channelId`;
 
-	public async fetchTextTracks(attachmentId: string) {
-		const video = await fApi.content.video(attachmentId);
-		return video.textTracks?.filter((track) => track.kind === "captions") ?? [];
-	}
-
 	private async *matchChannel(blogPost: BlogPost): AsyncGenerator<Video> {
 		if (blogPost.videoAttachments === undefined) return;
 		let dateOffset = 0;

--- a/src/lib/Subscription.ts
+++ b/src/lib/Subscription.ts
@@ -59,7 +59,7 @@ export default class Subscription {
 	private static isChannelCache: Record<string, isChannel> = {};
 	private static isChannelHelper = `const isChannel = (post, channelId) => (typeof post.channel !== 'string' ? post.channel.id : post.channel) === channelId`;
 
-	private async fetchTextTracks(attachmentId: string) {
+	public async fetchTextTracks(attachmentId: string) {
 		const video = await fApi.content.video(attachmentId);
 		return video.textTracks?.filter((track) => track.kind === "captions") ?? [];
 	}

--- a/src/lib/defaults.ts
+++ b/src/lib/defaults.ts
@@ -60,6 +60,7 @@ export const defaultSettings: Settings = {
 		downloadArtwork: true,
 		saveNfo: true,
 		considerAllNonPartialDownloaded: false,
+		downloadCaptions: true,
 	},
 	artworkSuffix: "",
 	postProcessingCommand: "",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,6 +45,7 @@ export interface Extras extends Record<string, boolean> {
 	downloadArtwork: boolean;
 	saveNfo: boolean;
 	considerAllNonPartialDownloaded: boolean;
+	downloadCaptions: boolean;
 }
 
 export type Resolution = ValueOfA<Resolutions>;

--- a/wiki/settings.md
+++ b/wiki/settings.md
@@ -168,6 +168,18 @@ This may result in files without muxed metadata and should only be used for reco
 
 <br>
 
+**extras.downloadCaptions**:  
+Controls whether video captions/subtitles are downloaded when available.  
+Caption files are saved as `.vtt` files in the same directory as the video.
+
+```json
+"extras": {
+    "downloadCaptions": true
+}
+```
+
+<br>
+
 ## Plex
 
 Use **quickstartPrompts** to easily set plex settings.


### PR DESCRIPTION
Will download captions to the same folder as the video when `downloadCaptions` flag is enabled.
If they are available when the video is first downloaded they will download with it. Otherwise, it will keep checking if any of the last `videosToSearch` has any new text tracks added every 5 minutes with the new video fetch.