### PR TITLE
Add 'downloadWaitTime' setting

### DIFF
--- a/src/lib/Video.ts
+++ b/src/lib/Video.ts
@@ -77,7 +77,7 @@ export class Video extends Attachment {
 	private static readonly MaxRetries = 1;
 	private static readonly DownloadThreads = 8;
 
-	private static readonly DownloadSemaphore = new Semaphore(this.DownloadThreads);
+	private static readonly DownloadSemaphore = new Semaphore(settings.downloadWaitTime > 0 ? 1 : this.DownloadThreads);
 
 	private static readonly ThrottleOptions: ThrottleOptions = { rate: settings.maxDownloadSpeed * byteToMbits };
 	private static readonly ThrottleGroup = settings.maxDownloadSpeed > -1 ? new ThrottleGroup(Video.ThrottleOptions) : undefined;
@@ -155,6 +155,10 @@ export class Video extends Attachment {
 		} finally {
 			release();
 			promQueued.dec();
+			// Wait between downloads if downloadWaitTime is set
+			if (settings.downloadWaitTime > 0) {
+				await sleep(settings.downloadWaitTime * 1000);
+			}
 		}
 	}
 

--- a/src/lib/defaults.ts
+++ b/src/lib/defaults.ts
@@ -46,6 +46,7 @@ export const defaultSettings: Settings = {
 		waitForNewVideos: true,
 		seekAndDestroy: [],
 	},
+	downloadWaitTime: 0,
 	maxDownloadSpeed: -1,
 	plex: {
 		sectionsToUpdate: [],

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -69,6 +69,7 @@ export type Settings = {
 		waitForNewVideos: boolean;
 		seekAndDestroy: string[];
 	};
+	downloadWaitTime: number;
 	maxDownloadSpeed: number;
 	filePathFormatting: string;
 	plex: PlexSettings;

--- a/wiki/settings.md
+++ b/wiki/settings.md
@@ -96,6 +96,17 @@ Added for Kodi support as Kodi looks for artwork in the format `VideoName-thumb.
 
 <br>
 
+**downloadWaitTime**:  
+Wait time (in seconds) between downloads. Default is 0 (disabled).  
+When set to a value greater than 0, downloads will be performed sequentially with the specified wait time between each download.  
+This helps prevent overloading the Floatplane servers with concurrent requests and reduces the risk of being rate-limited.
+
+```json
+"downloadWaitTime": 0
+```
+
+<br>
+
 **maxDownloadSpeed**:  
 The maximum speed to download at in mbps.
 


### PR DESCRIPTION
Controls how much time FPD should wait before downloading the next video. Could be useful for when downloading the entire backlog (that's what I'm doing right now!)