### PR TITLE
fix: correct 'occoured' to 'occurred' typo in error log message

### DIFF
--- a/src/lib/logging/ProgressConsole.ts
+++ b/src/lib/logging/ProgressConsole.ts
@@ -5,7 +5,7 @@ export class ProgressHeadless extends ProgressLogger implements IProgressLogger 
 		console.log(`${this.title} - ${message}`);
 	}
 	public error(err: unknown) {
-		this.log(`An error occoured: ${ProgressLogger.sanitizeError(err)}`);
+		this.log(`An error occurred: ${ProgressLogger.sanitizeError(err)}`);
 	}
 	public done = this.log;
 	public onDownloadProgress() {}


### PR DESCRIPTION
Fix a typo in the user-facing error log message in `src/lib/logging/ProgressConsole.ts`: `occoured` → `occurred`.

## Changes
- `src/lib/logging/ProgressConsole.ts` line 8: `this.log(`An error occoured: ...`)` → `this.log(`An error occurred: ...`)`

Happy to address any feedback!