### PR TITLE
fix: correct 'An error occoured' to 'An error occurred' in ProgressConsole.ts

### DIFF
--- a/src/lib/logging/ProgressConsole.ts
+++ b/src/lib/logging/ProgressConsole.ts
@@ -5,7 +5,7 @@ export class ProgressHeadless extends ProgressLogger implements IProgressLogger 
 		console.log(`${this.title} - ${message}`);
 	}
 	public error(err: unknown) {
-		this.log(`An error occoured: ${ProgressLogger.sanitizeError(err)}`);
+		this.log(`An error occurred: ${ProgressLogger.sanitizeError(err)}`);
 	}
 	public done = this.log;
 	public onDownloadProgress() {}


### PR DESCRIPTION
## Summary
Fix user-facing typo in error logging (ProgressConsole.ts line 8):

- **Before**: `An error occoured: {err}`
- **After**: `An error occurred: {err}`

Simple 1-line surgical fix.

---
*Submitted via automated PR攻关 agent*